### PR TITLE
Fix: incorrect argument usage in Challenge 4 (of the session 9)

### DIFF
--- a/challenge-eight/challenge-four.sh
+++ b/challenge-eight/challenge-four.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
+read -p "Please enter your direcroty path: " directory_path
 list_files() {
-  for file in $1/*; do
+    for file in $(ls "$1"/*); do
     echo $file
     if [[ -d $file ]]; then
       list_files $file
@@ -9,4 +10,5 @@ list_files() {
   done
 }
 
+list_files $directory_path
 


### PR DESCRIPTION
### Issue
The script output does not match the expected result.
The issue is caused by the incorrect usage of the argument "$1".

### Original Code (Buggy)
```bash
#!/bin/bash

list_files() {
  for file in $1/*; do
    echo $file
    if [[ -d $file ]]; then
      list_files $file
    fi
  done
}
```
### Fixed Code
```bash
#!/bin/bash

read -p "Please enter your directory path: " directory_path
list_files() {
    for file in $(ls "$1"/*); do
    echo $file
    if [[ -d $file ]]; then
      list_files $file
    fi
  done
}

list_files $directory_path
```